### PR TITLE
fix hash verification for iPhoneX

### DIFF
--- a/img4tool/img4tool.cpp
+++ b/img4tool/img4tool.cpp
@@ -1013,13 +1013,14 @@ bool tihmstar::img4tool::im4mMatchesBuildIdentity(const ASN1DERElement &im4m, pl
             
             {
                 bool doContinue = false;
-                for (auto &ignore : {"BasebandFirmware"}) {
+                for (auto &ignore : {"BasebandFirmware","ftap","ftsp","rfta","rfts","SE,Bootloader","SE,Firmware","SE,MigrationOS","SE,OS","SE,UpdatePayload"}) {
                     if (!strcmp(eKey, ignore)) {
                         printf("IGN (ignoring due to whitelist)\n");
                         doContinue = true;
                     }
                 }
                 if (doContinue) {
+                    checksPassed = true;
                     continue;
                 }
             }


### PR DESCRIPTION
**before**

img4tool version: 0.162-d514ce57f4a104aebe4ba8c20cd7c45f33cf3a68
[IMG4TOOL] checking buildidentity 0:
[IMG4TOOL] checking buildidentity matches board ... YES
[IMG4TOOL] checking buildidentity has all required hashes:
[IMG4TOOL] checking hash for "AOP"                     OK (found "aopf" with matching hash)
[IMG4TOOL] checking hash for "AppleLogo"               OK (found "logo" with matching hash)
[IMG4TOOL] checking hash for "AudioCodecFirmware"      OK (found "acfw" with matching hash)
[IMG4TOOL] checking hash for "BasebandFirmware"        IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "BatteryCharging0"        OK (found "chg0" with matching hash)
[IMG4TOOL] checking hash for "BatteryCharging1"        OK (found "chg1" with matching hash)
[IMG4TOOL] checking hash for "BatteryFull"             OK (found "batF" with matching hash)
[IMG4TOOL] checking hash for "BatteryLow0"             OK (found "bat0" with matching hash)
[IMG4TOOL] checking hash for "BatteryLow1"             OK (found "bat1" with matching hash)
[IMG4TOOL] checking hash for "BatteryPlugin"           OK (found "glyP" with matching hash)
[IMG4TOOL] checking hash for "DeviceTree"              OK (found "dtre" with matching hash)
[IMG4TOOL] checking hash for "KernelCache"             OK (found "krnl" with matching hash)
[IMG4TOOL] checking hash for "LLB"                     OK (found "illb" with matching hash)
[IMG4TOOL] checking hash for "Liquid"                  OK (found "liqd" with matching hash)
[IMG4TOOL] checking hash for "Multitouch"              OK (found "mtfw" with matching hash)
[IMG4TOOL] checking hash for "OS"                      OK (found "rosi" with matching hash)
[IMG4TOOL] checking hash for "RecoveryMode"            OK (found "recm" with matching hash)
[IMG4TOOL] checking hash for "RestoreDeviceTree"       OK (found "rdtr" with matching hash)
[IMG4TOOL] checking hash for "RestoreKernelCache"      OK (found "rkrn" with matching hash)
[IMG4TOOL] checking hash for "RestoreLogo"             OK (found "rlgo" with matching hash)
[IMG4TOOL] checking hash for "RestoreRamDisk"          OK (found "rdsk" with matching hash)
[IMG4TOOL] checking hash for "RestoreSEP"              OK (found "rsep" with matching hash)
[IMG4TOOL] checking hash for "RestoreTrustCache"       OK (found "rtsc" with matching hash)
[IMG4TOOL] checking hash for "SE,UpdatePayload"        
failed verification with error:
[exception]:
what=assure failed
code=67436556
line=1029
file=img4tool.cpp
commit count=26:
commit sha  =4c96389db50eeb7411f6e4c62eb073ef401ca6bd:
[IMG4TOOL] checking buildidentity 1:
[IMG4TOOL] checking buildidentity matches board ... NO
[IMG4TOOL] checking buildidentity 2:
[IMG4TOOL] checking buildidentity matches board ... YES
[IMG4TOOL] checking buildidentity has all required hashes:
[IMG4TOOL] checking hash for "AOP"                     OK (found "aopf" with matching hash)
[IMG4TOOL] checking hash for "AppleLogo"               OK (found "logo" with matching hash)
[IMG4TOOL] checking hash for "AudioCodecFirmware"      OK (found "acfw" with matching hash)
[IMG4TOOL] checking hash for "BasebandFirmware"        IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "BatteryCharging0"        OK (found "chg0" with matching hash)
[IMG4TOOL] checking hash for "BatteryCharging1"        OK (found "chg1" with matching hash)
[IMG4TOOL] checking hash for "BatteryFull"             OK (found "batF" with matching hash)
[IMG4TOOL] checking hash for "BatteryLow0"             OK (found "bat0" with matching hash)
[IMG4TOOL] checking hash for "BatteryLow1"             OK (found "bat1" with matching hash)
[IMG4TOOL] checking hash for "BatteryPlugin"           OK (found "glyP" with matching hash)
[IMG4TOOL] checking hash for "DeviceTree"              OK (found "dtre" with matching hash)
[IMG4TOOL] checking hash for "KernelCache"             OK (found "krnl" with matching hash)
[IMG4TOOL] checking hash for "LLB"                     OK (found "illb" with matching hash)
[IMG4TOOL] checking hash for "Liquid"                  OK (found "liqd" with matching hash)
[IMG4TOOL] checking hash for "Multitouch"              OK (found "mtfw" with matching hash)
[IMG4TOOL] checking hash for "OS"                      OK (found "rosi" with matching hash)
[IMG4TOOL] checking hash for "RecoveryMode"            OK (found "recm" with matching hash)
[IMG4TOOL] checking hash for "RestoreDeviceTree"       OK (found "rdtr" with matching hash)
[IMG4TOOL] checking hash for "RestoreKernelCache"      OK (found "rkrn" with matching hash)
[IMG4TOOL] checking hash for "RestoreLogo"             OK (found "rlgo" with matching hash)
[IMG4TOOL] checking hash for "RestoreRamDisk"          BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "RestoreSEP"              OK (found "rsep" with matching hash)
[IMG4TOOL] checking hash for "RestoreTrustCache"       BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "SE,UpdatePayload"        
failed verification with error:
[exception]:
what=assure failed
code=67436556
line=1029
file=img4tool.cpp
commit count=26:
commit sha  =4c96389db50eeb7411f6e4c62eb073ef401ca6bd:
[IMG4TOOL] checking buildidentity 3:
[IMG4TOOL] checking buildidentity matches board ... NO

[IMG4TOOL] IM4M validation failed with error:
[exception]:
what=Failed to find matching buildidentity
code=72810508
line=1111
file=img4tool.cpp
commit count=26:
commit sha  =4c96389db50eeb7411f6e4c62eb073ef401ca6bd:

[IMG4TOOL] APTicket is BAD!


**after**

img4tool version: 0.162-d514ce57f4a104aebe4ba8c20cd7c45f33cf3a68
[IMG4TOOL] checking buildidentity 0:
[IMG4TOOL] checking buildidentity matches board ... YES
[IMG4TOOL] checking buildidentity has all required hashes:
[IMG4TOOL] checking hash for "AOP"                     OK (found "aopf" with matching hash)
[IMG4TOOL] checking hash for "AppleLogo"               OK (found "logo" with matching hash)
[IMG4TOOL] checking hash for "AudioCodecFirmware"      OK (found "acfw" with matching hash)
[IMG4TOOL] checking hash for "BasebandFirmware"        IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "BatteryCharging0"        OK (found "chg0" with matching hash)
[IMG4TOOL] checking hash for "BatteryCharging1"        OK (found "chg1" with matching hash)
[IMG4TOOL] checking hash for "BatteryFull"             OK (found "batF" with matching hash)
[IMG4TOOL] checking hash for "BatteryLow0"             OK (found "bat0" with matching hash)
[IMG4TOOL] checking hash for "BatteryLow1"             OK (found "bat1" with matching hash)
[IMG4TOOL] checking hash for "BatteryPlugin"           OK (found "glyP" with matching hash)
[IMG4TOOL] checking hash for "DeviceTree"              OK (found "dtre" with matching hash)
[IMG4TOOL] checking hash for "KernelCache"             OK (found "krnl" with matching hash)
[IMG4TOOL] checking hash for "LLB"                     OK (found "illb" with matching hash)
[IMG4TOOL] checking hash for "Liquid"                  OK (found "liqd" with matching hash)
[IMG4TOOL] checking hash for "Multitouch"              OK (found "mtfw" with matching hash)
[IMG4TOOL] checking hash for "OS"                      OK (found "rosi" with matching hash)
[IMG4TOOL] checking hash for "RecoveryMode"            OK (found "recm" with matching hash)
[IMG4TOOL] checking hash for "RestoreDeviceTree"       OK (found "rdtr" with matching hash)
[IMG4TOOL] checking hash for "RestoreKernelCache"      OK (found "rkrn" with matching hash)
[IMG4TOOL] checking hash for "RestoreLogo"             OK (found "rlgo" with matching hash)
[IMG4TOOL] checking hash for "RestoreRamDisk"          OK (found "rdsk" with matching hash)
[IMG4TOOL] checking hash for "RestoreSEP"              OK (found "rsep" with matching hash)
[IMG4TOOL] checking hash for "RestoreTrustCache"       OK (found "rtsc" with matching hash)
[IMG4TOOL] checking hash for "SE,UpdatePayload"        IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "SEP"                     OK (found "sepi" with matching hash)
[IMG4TOOL] checking hash for "Savage,B0-Dev-Patch"     BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B0-Dev-PatchVT"   BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B0-Prod-Patch"    BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B0-Prod-PatchVT"  BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B2-Dev-Patch"     BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B2-Dev-PatchVT"   BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B2-Prod-Patch"    BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,B2-Prod-PatchVT"  BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,BA-Dev-Patch"     BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "Savage,BA-Prod-Patch"    BAD! (hash not found in im4m)
[IMG4TOOL] checking hash for "StaticTrustCache"        OK (found "trst" with matching hash)
[IMG4TOOL] checking hash for "ftap"                    IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "ftsp"                    IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "iBEC"                    OK (found "ibec" with matching hash)
[IMG4TOOL] checking hash for "iBSS"                    OK (found "ibss" with matching hash)
[IMG4TOOL] checking hash for "iBoot"                   OK (found "ibot" with matching hash)
[IMG4TOOL] checking hash for "rfta"                    IGN (ignoring due to whitelist)
[IMG4TOOL] checking hash for "rfts"                    IGN (ignoring due to whitelist)

[IMG4TOOL] IM4M signature is verified by TssAuthority
[IMG4TOOL] IM4M is valid for the given BuildManifest for the following restore:
BuildNumber : 16G77
BuildTrain : PeaceG
DeviceClass : d221ap
FDRSupport : YES
MobileDeviceMinVersion : 988.200.73
RestoreBehavior : Erase
Variant : Customer Erase Install (IPSW)

[IMG4TOOL] APTicket is GOOD!