### PR TITLE
Add missing algorithm header to main.cpp

### DIFF
--- a/img4tool/main.cpp
+++ b/img4tool/main.cpp
@@ -12,6 +12,7 @@
 #include <getopt.h>
 #include <string.h>
 #include <stdlib.h>
+#include <algorithm>
 
 #include <libgeneral/macros.h>
 #include "img4tool.hpp"


### PR DESCRIPTION
371ef6a8e0260bd15b0d3ccc29bb25d8a5dd7a4d fixed #31 for `img4tool.cpp`, but the issue still exists in `main.cpp`:
```
main.cpp: In function ‘int main_r(int, const char**)’:
main.cpp:384:26: error: ‘reverse’ is not a member of ‘std’
  384 |                     std::reverse(octetString.begin(), octetString.end());
      |                          ^~~~~~~
```
To fix this, add `#include <algorithm>` to `main.cpp`.
(moved from elp0t0r1c0#1)