### PR TITLE
Update libplist name for 2.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ CFLAGS+=" -std=c11"
 
 # Checks for libraries.
 OPENSSL_REQUIRES_STR="openssl >= 0.9.8"
-LIBPLIST_REQUIRES_STR="libplist >= 2.0.0"
+LIBPLIST_REQUIRES_STR="libplist-2.0 >= 2.2.0"
 LIBGENERAL_REQUIRES_STR="libgeneral >= 26"
 PKG_CHECK_MODULES(openssl, $OPENSSL_REQUIRES_STR, have_openssl=yes, have_openssl=no)
 PKG_CHECK_MODULES(libplist, $LIBPLIST_REQUIRES_STR, have_plist=yes, have_plist=no)


### PR DESCRIPTION
Fixes #44

Version 2.2.0 of libplist changed the library name from `libplist` to `libplist-2.0`, which causes img4tool to not find the library. This patch fixes that.